### PR TITLE
Default to `minor` version, do not ci-build on push to main

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -1,9 +1,6 @@
 name: CI Build
 
 on:
-  push:
-    paths-ignore:
-      - '**.md'
   pull_request:
     paths-ignore:
       - '**.md'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,7 +5,7 @@ on:
     inputs:
       versionModifier:
         description: 'Version Modifier'
-        default: 'patch'
+        default: 'minor'
         type: choice
         required: true
         options:


### PR DESCRIPTION
The build that happens on a push to `main` is useless because nothing happens at that point. The build should always pass before a PR is merged, and when a manual release happens it does its own build! Consider this cleanup 🙂 