### PR TITLE
Add internal Figure mirror to repository resolution

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -12,16 +12,18 @@ dependencyResolutionManagement {
             }
         }
         maven { // needed for p8e-gradle-plugin
-            url = uri("https://nexus.figure.com/repository/figure")
+            url = uri("https://nexus.figure.com/repository/mirror")
             credentials {
                 username = System.getenv("NEXUS_USER")
                 password = System.getenv("NEXUS_PASS")
             }
         }
-        mavenCentral()
-        gradlePluginPortal()
-        maven {
-            url = uri("https://jitpack.io")
+        maven { // needed for p8e-gradle-plugin
+            url = uri("https://nexus.figure.com/repository/figure")
+            credentials {
+                username = System.getenv("NEXUS_USER")
+                password = System.getenv("NEXUS_PASS")
+            }
         }
     }
 }
@@ -37,13 +39,19 @@ pluginManagement {
             }
         }
         maven { // needed for p8e-gradle-plugin
+            url = uri("https://nexus.figure.com/repository/mirror")
+            credentials {
+                username = System.getenv("NEXUS_USER")
+                password = System.getenv("NEXUS_PASS")
+            }
+        }
+        maven { // needed for p8e-gradle-plugin
             url = uri("https://nexus.figure.com/repository/figure")
             credentials {
                 username = System.getenv("NEXUS_USER")
                 password = System.getenv("NEXUS_PASS")
             }
         }
-        gradlePluginPortal()
     }
 
     includeBuild("build-logic")


### PR DESCRIPTION
I've been seeing errors around dependencies that can't resolve or time out because of the semver plugin, often times this happens to be the `arrow` dependency. I'm not quite sure why it always is that one - alphabetical? Or because it's using JCenter? :shrug:

Either way - this PR adds the internal mirror to our repository list which should significantly improve reliability and speed for dependency resolution on this project.
