### PR TITLE
Fix the double publishing

### DIFF
--- a/build-logic/build-conventions/src/main/kotlin/local.figure.publishing.gradle.kts
+++ b/build-logic/build-conventions/src/main/kotlin/local.figure.publishing.gradle.kts
@@ -41,7 +41,6 @@ pluginBundle {
 }
 
 gradlePlugin {
-
     plugins {
         create(project.name) {
             id = "$group.${project.name}"
@@ -62,49 +61,49 @@ publishing {
             }
         }
     }
-    publications {
-        create<MavenPublication>("mavenJava") {
-            pom {
-                // This line is what includes the java{} block, aka javadocs and sources
-                from(components["java"])
+    // publications {
+    //     create<MavenPublication>("mavenJava") {
+    //         pom {
+    //             // This line is what includes the java{} block, aka javadocs and sources
+    //             from(components["java"])
 
-                name.set(info.longName)
-                description.set(info.description)
-                url.set(info.website)
-                licenses {
-                    license {
-                        name.set("The Apache License, Version 2.0")
-                        url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("ahatzz11")
-                        name.set("Alex Hatzenbuhler")
-                        email.set("ahatzenbuhler@figure.com")
-                    }
-                    developer {
-                        id.set("happyphan")
-                        name.set("Emily Harris")
-                        email.set("eharris@figure.com")
-                    }
-                    developer {
-                        id.set("luinstra")
-                        name.set("Jeremy Luinstra")
-                        email.set("jluinstra@figure.com")
-                    }
-                    developer {
-                        id.set("jonasg13")
-                        name.set("Jonas Gorauskas")
-                        email.set("jgorauskas@figure.com")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:git://github.com/FigureTechnologies/gradle-semver-plugin.git")
-                    developerConnection.set("scm:git:ssh://github.com/FigureTechnologies/gradle-semver-plugin.git")
-                    url.set(info.website)
-                }
-            }
-        }
-    }
+    //             name.set(info.longName)
+    //             description.set(info.description)
+    //             url.set(info.website)
+    //             licenses {
+    //                 license {
+    //                     name.set("The Apache License, Version 2.0")
+    //                     url.set("http://www.apache.org/licenses/LICENSE-2.0.txt")
+    //                 }
+    //             }
+    //             developers {
+    //                 developer {
+    //                     id.set("ahatzz11")
+    //                     name.set("Alex Hatzenbuhler")
+    //                     email.set("ahatzenbuhler@figure.com")
+    //                 }
+    //                 developer {
+    //                     id.set("happyphan")
+    //                     name.set("Emily Harris")
+    //                     email.set("eharris@figure.com")
+    //                 }
+    //                 developer {
+    //                     id.set("luinstra")
+    //                     name.set("Jeremy Luinstra")
+    //                     email.set("jluinstra@figure.com")
+    //                 }
+    //                 developer {
+    //                     id.set("jonasg13")
+    //                     name.set("Jonas Gorauskas")
+    //                     email.set("jgorauskas@figure.com")
+    //                 }
+    //             }
+    //             scm {
+    //                 connection.set("scm:git:git://github.com/FigureTechnologies/gradle-semver-plugin.git")
+    //                 developerConnection.set("scm:git:ssh://github.com/FigureTechnologies/gradle-semver-plugin.git")
+    //                 url.set(info.website)
+    //             }
+    //         }
+    //     }
+    // }
 }


### PR DESCRIPTION
This was successful, as seen by these two artifacts:
- https://nexus.figure.com/service/rest/repository/browse/figure/com/figure/gradle/semver-plugin/0.8.1-fix-publishing.1/
- https://nexus.figure.com/service/rest/repository/browse/figure/com/figure/gradle/semver-plugin/com.figure.gradle.semver-plugin.gradle.plugin/0.8.1-fix-publishing.1/

This worked because the gradle publishing is responsible for publishing the gradle plygin data to maven _and_ the jar, which the maven publish then tried to re-publish to nexus but fails. Removing the extra metadata (for now) is the answer. 

Once we're OSS this metadata is required, but this publishing will need some re-work anyway to publish to public sources.