### PR TITLE
Move actions to public runners

### DIFF
--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -17,4 +17,4 @@ jobs:
           disable-releaser: true
           config-name: autolabeler.yml
         env:
-          GITHUB_TOKEN: ${{ inputs.github_token }}
+          GITHUB_TOKEN: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/autolabeler.yaml
+++ b/.github/workflows/autolabeler.yaml
@@ -10,15 +10,11 @@ jobs:
   autolabel-pr:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout Figure shared actions
-        uses: actions/checkout@v3
+      - name: Autolabel PR
+        uses: release-drafter/release-drafter@v5
         with:
-          repository: FigureTechnologies/shared-actions
-          ref: v1
-          token: ${{ secrets.PAT }}
-          path: shared-actions
-
-      - name: Autolabeler
-        uses: ./shared-actions/autolabeler
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # never make a release, that is done by githubRelease
+          disable-releaser: true
+          config-name: autolabeler.yml
+        env:
+          GITHUB_TOKEN: ${{ inputs.github_token }}

--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: [linux, self-hosted]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up JDK 11

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -25,7 +25,7 @@ env:
 
 jobs:
   build-and-publish:
-    runs-on: [linux, self-hosted]
+    runs-on: ubuntu-latest
 
     steps:
       - name: Set up JDK 11
@@ -48,9 +48,9 @@ jobs:
             echo '::set-output name=publishCommand::'
           else
             echo 'not skipping publish'
-            echo '::set-output name=publishCommand::publish'            
+            echo '::set-output name=publishCommand::publish'
           fi
-          
+
           if [ ${{ github.ref }} != 'refs/heads/main' ]; then
             echo 'SKIPPING github release since this is a branch release'
             echo '::set-output name=githubReleaseCommand::'

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ This calculated semantic version is then available as an output with the extensi
 | _latest version_               | The latest published git tag on the target branch.                                     | `1.0.2`   |
 | _current / calculated version_ | The version that is calculated when it runs. This will be ahead of the latest version. | `1.0.3`   |
 
-
 ### Plugin Extension Properties
 
 These variables come from the plugin extension, and are only available after the `semver {}` extension is configured.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -107,7 +107,7 @@ tasks.withType<Test>().configureEach {
 }
 
 // project version, also used for publishing
-version = 1.1.0
+version = "1.1.0"
 // version = semver.version
 
 val githubTokenValue = findProperty("githubToken")?.toString() ?: System.getenv("GITHUB_TOKEN")
@@ -116,7 +116,8 @@ githubRelease {
     token(githubTokenValue)
     owner("FigureTechnologies")
     repo("gradle-semver-plugin")
-    tagName(semver.versionTagName)
+    // tagName(semver.versionTagName)
+    tagName("v1.1.0")
     targetCommitish("main")
     body("")
     generateReleaseNotes(true)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 //    signing
     alias(libs.plugins.github.release)
     alias(libs.plugins.kotlin.jvm)
-    alias(libs.plugins.semver)
+    // alias(libs.plugins.semver)
     alias(libs.plugins.dependency.analysis)
 
     id("local.figure.publishing") // maven and gradle publishing info - build-logic/publishing
@@ -18,13 +18,13 @@ plugins {
     id("org.cadixdev.licenser") version "0.6.1"
 }
 
-semver {
-    tagPrefix("v")
-    initialVersion("0.0.1")
-    findProperty("semver.overrideVersion")?.toString()?.let { overrideVersion(it) }
-    findProperty("semver.modifier")?.toString()
-        ?.let { versionModifier(buildVersionModifier(it)) } // this is only used for non user defined strategies, ie predefined Flow or Flat
-}
+// semver {
+//     tagPrefix("v")
+//     initialVersion("0.0.1")
+//     findProperty("semver.overrideVersion")?.toString()?.let { overrideVersion(it) }
+//     findProperty("semver.modifier")?.toString()
+//         ?.let { versionModifier(buildVersionModifier(it)) } // this is only used for non user defined strategies, ie predefined Flow or Flat
+// }
 
 configurations.all {
     resolutionStrategy {
@@ -107,7 +107,8 @@ tasks.withType<Test>().configureEach {
 }
 
 // project version, also used for publishing
-version = semver.version
+version = 1.1.0
+// version = semver.version
 
 val githubTokenValue = findProperty("githubToken")?.toString() ?: System.getenv("GITHUB_TOKEN")
 


### PR DESCRIPTION
Our self-hosted runners don't currently support building public repos for security reasons, so moving these workflows to `ubuntu-latest`.

[sc-210791]