### PR TITLE
Use new kotlin/gradle toolchain

### DIFF
--- a/.github/workflows/ci-build.yaml
+++ b/.github/workflows/ci-build.yaml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'zulu'
 
       - name: Checkout

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,10 +28,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'zulu'
 
       - name: Checkout

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,7 +8,6 @@ plugins {
 //    signing
     alias(libs.plugins.github.release)
     alias(libs.plugins.kotlin.jvm)
-    // alias(libs.plugins.semver)
     alias(libs.plugins.dependency.analysis)
 
     id("local.figure.publishing") // maven and gradle publishing info - build-logic/publishing
@@ -70,15 +69,17 @@ configurations.all {
     }
 }
 
+
 kotlin {
+    // Configures Java toolchain both for Kotlin JVM and Java tasks
+    jvmToolchain(17)
     target {
         compilations.all {
             kotlinOptions {
                 freeCompilerArgs =
                     freeCompilerArgs + listOf("-version", "-Xjsr305=strict", "-opt-in=kotlin.RequiresOptIn")
-                jvmTarget = "11"
-                languageVersion = "1.8"
-                apiVersion = "1.8"
+                // languageVersion = "1.8"
+                // apiVersion = "1.8"
                 verbose = true
             }
         }
@@ -88,11 +89,6 @@ kotlin {
 java {
     withSourcesJar()
     withJavadocJar()
-}
-
-tasks.withType<JavaCompile>().configureEach {
-    sourceCompatibility = JavaVersion.VERSION_11.toString()
-    targetCompatibility = sourceCompatibility
 }
 
 tasks.withType<Test>().configureEach {
@@ -153,3 +149,6 @@ tasks.named("assemble") {
 tasks.wrapper {
     distributionType = Wrapper.DistributionType.ALL
 }
+
+logger.lifecycle("JDK toolchain version: ${java.toolchain.languageVersion.get()}")
+logger.lifecycle("Kotlin version: ${extensions.findByType<org.jetbrains.kotlin.gradle.dsl.KotlinTopLevelExtension>()?.coreLibrariesVersion}")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,7 +70,6 @@ configurations.all {
     }
 }
 
-
 kotlin {
     // Configures Java toolchain both for Kotlin JVM and Java tasks
     jvmToolchain(17)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -78,8 +78,6 @@ kotlin {
             kotlinOptions {
                 freeCompilerArgs =
                     freeCompilerArgs + listOf("-version", "-Xjsr305=strict", "-opt-in=kotlin.RequiresOptIn")
-                // languageVersion = "1.8"
-                // apiVersion = "1.8"
                 verbose = true
             }
         }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 //    signing
     alias(libs.plugins.github.release)
     alias(libs.plugins.kotlin.jvm)
+    // alias(libs.plugins.semver)
     alias(libs.plugins.dependency.analysis)
 
     id("local.figure.publishing") // maven and gradle publishing info - build-logic/publishing

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,7 +72,7 @@ configurations.all {
 
 kotlin {
     // Configures Java toolchain both for Kotlin JVM and Java tasks
-    jvmToolchain(17)
+    jvmToolchain(11)
     target {
         compilations.all {
             kotlinOptions {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,3 +3,5 @@ kotlin.code.style=official
 semver.currentBranch.scope=patch
 org.gradle.caching=true
 org.gradle.parallel=true
+
+


### PR DESCRIPTION
Gradle8 fixes some stuff with how kotlin can use the toolchain, so I've cleaned this up! 


This finally works the way you'd expect, and properly sets up the jvm version for both java and kotlin compile tasks:
```
kotlin {
    jvmToolchain(11)
}
```