### PR TITLE
Fix publishing command

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -43,7 +43,7 @@ jobs:
             echo 'SKIPPING publish'
           else
             echo 'publishing!'
-            echo "publishCommand=publish" >> $GITHUB_OUTPUT
+            echo "publishCommand=publishPlugins" >> $GITHUB_OUTPUT
           fi
 
           if [ ${{ github.ref }} != 'refs/heads/main' ]; then


### PR DESCRIPTION
Gradle publish plugin uses the `publishPlugin` task, not the `publish` task. 
