### PR TITLE
Add versioning with gradle-semver-plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,10 +5,9 @@ import org.jetbrains.kotlin.config.KotlinCompilerVersion.VERSION as KOTLIN_VERSI
 
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
-//    signing
     alias(libs.plugins.github.release)
     alias(libs.plugins.kotlin.jvm)
-    // alias(libs.plugins.semver)
+    alias(libs.plugins.semver)
     alias(libs.plugins.dependency.analysis)
 
     id("local.figure.publishing") // maven and gradle publishing info - build-logic/publishing
@@ -18,13 +17,13 @@ plugins {
     id("org.cadixdev.licenser") version "0.6.1"
 }
 
-// semver {
-//     tagPrefix("v")
-//     initialVersion("0.0.1")
-//     findProperty("semver.overrideVersion")?.toString()?.let { overrideVersion(it) }
-//     findProperty("semver.modifier")?.toString()
-//         ?.let { versionModifier(buildVersionModifier(it)) } // this is only used for non user defined strategies, ie predefined Flow or Flat
-// }
+semver {
+    tagPrefix("v")
+    initialVersion("0.0.1")
+    findProperty("semver.overrideVersion")?.toString()?.let { overrideVersion(it) }
+    findProperty("semver.modifier")?.toString()
+        ?.let { versionModifier(buildVersionModifier(it)) } // this is only used for non user defined strategies, ie predefined Flow or Flat
+}
 
 configurations.all {
     resolutionStrategy {
@@ -101,8 +100,7 @@ tasks.withType<Test>().configureEach {
 }
 
 // project version, also used for publishing
-version = "1.1.0"
-// version = semver.version
+version = semver.version
 
 val githubTokenValue = findProperty("githubToken")?.toString() ?: System.getenv("GITHUB_TOKEN")
 
@@ -110,8 +108,7 @@ githubRelease {
     token(githubTokenValue)
     owner("FigureTechnologies")
     repo("gradle-semver-plugin")
-    // tagName(semver.versionTagName)
-    tagName("v1.1.0")
+    tagName(semver.versionTagName)
     targetCommitish("main")
     body("")
     generateReleaseNotes(true)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ swiftzer-semver = "1.2.0"
 # Plugin versions
 dependency-analysis = "1.19.0"
 github-release = "2.4.1"
-gradle-semver-plugin = "1.0.1"
+gradle-semver-plugin = "1.1.0"
 
 [libraries]
 


### PR DESCRIPTION
To get bootstrapped into the public gradle portal we needed a version, and we couldn't use our old private artifacts to import this plugin to do a version calculation, so I had to hardcode the `v1.1.0` version for the initial release. Now that there is a public artifact, we can go back to versioning with ourselves

🐔🥚  
