### PR TITLE
Update log with debugging tip

### DIFF
--- a/src/main/kotlin/com/figure/gradle/semver/internal/git/Git.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/git/Git.kt
@@ -124,7 +124,7 @@ private fun Git.findYoungestTagOnBranchOlderThanTarget(
 ): SemVer? {
     val branchRef = repository.exactRef(branch.refName)
     if (branchRef == null) {
-        log.semverError("Failed to find exact git ref for branch: $branch, aborting...")
+        log.semverError("Failed to find exact git ref for branch: $branch, aborting build. Check that the full git history is available.")
     } else {
         log.semverInfo("Pulling log for $branch refName, exactRef: $branchRef, target: $target")
     }
@@ -195,7 +195,7 @@ private fun Git.findYoungestTagCommitOnBranch(
 ): RevCommit? {
     val branchRef = repository.exactRef(branch.refName)
     if (branchRef == null) {
-        log.semverError("Failed to find exact git ref for branch [$branch], aborting...")
+        log.semverError("Failed to find exact git ref for branch: $branch, aborting build. Check that the full git history is available.")
     } else {
         log.semverInfo("Pulling log for $branch refName, exactRef: $branchRef")
     }


### PR DESCRIPTION
95% of the time we get some of these errors it is because the entire git history is not available, and we can't backtrack to the most recent tag. Hopefully this logging helps people debug when this happens in CI because of `fetch-depth`-style issues.
