### PR TITLE
feat(build,docs): bootstrap build, clarify docs

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -67,24 +67,6 @@ dependencies {
     functionalTestImplementation(libs.testkit.support)
 }
 
-@DisableCachingByDefault
-abstract class WriteVersionToFile : DefaultTask() {
-    @get:Input
-    abstract val versionProperty: Property<String>
-
-    init {
-        group = "build"
-        description = "Writes the project version to build/semver/semver.properties"
-    }
-
-    @TaskAction
-    fun writeVersion() {
-        val versionFile = File("build/semver/semver.properties")
-        versionFile.parentFile.mkdirs()
-        versionFile.writeText("version=${versionProperty.get()}")
-    }
-}
-
 tasks {
     withType<KotlinCompile>().configureEach {
         compilerOptions {
@@ -111,7 +93,6 @@ tasks {
 
     check {
         dependsOn("detekt")
-        dependsOn("writeVersionToFile")
     }
 
     withType<Detekt>().configureEach {
@@ -133,11 +114,6 @@ tasks {
         group = "verification"
         description = "Check all code using configured linters. Runs 'spotlessCheck'"
         dependsOn("spotlessCheck")
-    }
-
-    // Temporary solution until this plugin can be bootstrapped with itself
-    register<WriteVersionToFile>("writeVersionToFile") {
-        versionProperty = project.version.toString()
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,6 @@ plugins {
 }
 
 group = "com.figure.gradle.semver"
-version = "2.0.1"
 
 val testImplementation: Configuration by configurations.getting
 

--- a/docs/for-major-version.md
+++ b/docs/for-major-version.md
@@ -21,10 +21,20 @@ Latest tag: `v2.0.0`
 Latest v1 tag: `v1.5.9`
 
 ???+ note "Important Note"
-    If no stage or modifier is provided, a default of `auto` used.
+If no stage or modifier is provided, a default of `auto` used.
 
 | Command                                                                             | Next Version |
 |-------------------------------------------------------------------------------------|--------------|
 | `./gradlew -Psemver.forMajorVersion=1`                                              | 1.5.10       |
-| `./gradlew -Psemver.forMajorVersion=1` -Psemver.modifier=minor                      | 1.6.0        |
-| `./gradlew -Psemver.forMajorVersion=1` -Psemver.modifier=minor -Psemver.modifier=rc | 1.6.0-rc.1   |
+| `./gradlew -Psemver.forMajorVersion=1 -Psemver.modifier=minor`                      | 1.6.0        |
+| `./gradlew -Psemver.forMajorVersion=1 -Psemver.modifier=minor -Psemver.modifier=rc` | 1.6.0-rc.1   |
+
+### Suggested Workflow
+
+1. Identify and checkout the latest tag for the major version you want to
+   target.
+2. Create a new branch for your changes off the tag (e.g. `release/v1.x`).
+3. Make your changes and commit them to your new branch.
+4. Execute gradle build, publish, and release steps with
+   `-Psemver.forMajorVersion=<your-major-version>` to target the historical
+   major version line.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,6 +30,7 @@ dependencyResolutionManagement {
 
 plugins {
     id("com.gradle.develocity") version "3.18.1"
+    id("com.figure.gradle.semver") version "2.0.0"
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -30,7 +30,7 @@ dependencyResolutionManagement {
 
 plugins {
     id("com.gradle.develocity") version "3.18.1"
-    id("com.figure.gradle.semver") version "2.0.0"
+    id("com.figure.gradle.semver") version "2.0.1"
     id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
 }
 


### PR DESCRIPTION
Use the semver plugin to determine the next version of the semver plugin. Add a suggested workflow for using the `forMajorVersion` property