### PR TITLE
chore(publish): publish non-stable to internal repo

### DIFF
--- a/.github/workflows/gradle-release.yaml
+++ b/.github/workflows/gradle-release.yaml
@@ -12,11 +12,6 @@ on:
           - "patch"
           - "minor"
           - "major"
-      skip-publishing:
-        description: "Skip artifact publishing"
-        required: false
-        type: boolean
-        default: false
 
 env:
   GITHUB_TOKEN: ${{ secrets.PAT }}
@@ -37,26 +32,6 @@ jobs:
           java-version: '17'
           distribution: 'zulu'
 
-      - name: Set defaults for Build Parameters
-        id: build_parameters
-        shell: bash
-        run: |
-          if [ "$SKIP_PUBLISH" = "true" ]; then
-            echo 'SKIPPING publish'
-          else
-            echo 'publishing!'
-            echo "publishCommand=publishPlugins" >> $GITHUB_OUTPUT
-          fi
-
-          if [ ${{ github.ref }} != 'refs/heads/main' ]; then
-            echo 'SKIPPING github release since this is a branch release'
-          else
-            echo 'not skipping github release'
-            echo "githubReleaseCommand=githubRelease" >> $GITHUB_OUTPUT
-          fi
-        env:
-          SKIP_PUBLISH: ${{ github.event.inputs.skip-publishing }}
-
       - name: Install gpg secret key
         run: |
           export GPG_TTY=$(tty)
@@ -75,18 +50,56 @@ jobs:
             jdks
             wrapper
 
-      - name: Build, Publish, and Release
+      - name: Gradle Build
+        run: >-
+          ./gradlew build
+          -Psemver.modifier=${{ github.event.inputs.version-modifier }}
+          --stacktrace
+          --parallel
+          --build-cache
+
+      - name: Set Version Outputs
+        id: version-outputs
         run: |
-          ./gradlew \
-            -Psemver.modifier=${{ github.event.inputs.version-modifier }} \
-            build ${{ steps.build_parameters.outputs.publishCommand }} \
-            ${{ steps.build_parameters.outputs.githubReleaseCommand }} \
-            -Psigning.keyId=${{ secrets.OSSRH_GPG_SECRET_KEY_ID }} \
-            -Psigning.password=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }} \
-            -Psigning.secretKeyRingFile=release.gpg \
-            -Pgradle.publish.key=${{ secrets.OSS_GRADLE_PUBLISH_KEY }} \
-            -Pgradle.publish.secret=${{ secrets.OSS_GRADLE_PUBLISH_SECRET }} \
-            -Psigning.enabled=true \
-            --stacktrace \
-            --parallel \
+          sem_version=$(grep '^version=' build/semver/semver.properties | cut -d'=' -f2)
+          sem_version_tag=$(grep '^versionTag=' build/semver/semver.properties | cut -d'=' -f2)
+
+          echo "sem-version=$sem_version" >> $GITHUB_OUTPUT
+          echo "sem-version-tag=$sem_version_tag" >> $GITHUB_OUTPUT
+         
+          # Publish to gradle plugin portal only if stable version
+          # Create github release only if stable version
+          if [[ "$sem_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "publishCommand=publishPlugins" >> $GITHUB_OUTPUT
+            echo "githubReleaseCommand=githubRelease" >> $GITHUB_OUTPUT
+          else
+            echo "publishCommand=publishAllPublicationsToFigureNexusRepository" >> $GITHUB_OUTPUT
+            echo "githubReleaseCommand=" >> $GITHUB_OUTPUT
+          fi
+
+          echo "### Semantic Version" >> $GITHUB_STEP_SUMMARY
+          echo "| Field | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "| --- | --- |" >> $GITHUB_STEP_SUMMARY
+          echo "| version | ${sem_version} |" >> $GITHUB_STEP_SUMMARY
+          echo "| tag | ${sem_version_tag} |" >> $GITHUB_STEP_SUMMARY
+
+      - name: Gradle Publish
+        run: >-
+          ./gradlew ${{ steps.version-outputs.outputs.publishCommand }}
+          -Psemver.overrideVersion=${{ steps.version-outputs.outputs.sem-version }}
+          -Psigning.keyId=${{ secrets.OSSRH_GPG_SECRET_KEY_ID }}
+          -Psigning.password=${{ secrets.OSSRH_GPG_SECRET_KEY_PASSWORD }}
+          -Psigning.secretKeyRingFile=release.gpg
+          -Pgradle.publish.key=${{ secrets.OSS_GRADLE_PUBLISH_KEY }}
+          -Pgradle.publish.secret=${{ secrets.OSS_GRADLE_PUBLISH_SECRET }}
+          --stacktrace
+          --parallel
+          --build-cache
+
+      - name: Gradle Release
+        run: >-
+          ./gradlew ${{ steps.version-outputs.outputs.githubReleaseCommand }}
+            -Psemver.overrideVersion=${{ steps.version-outputs.outputs.sem-verion }}
+            --stacktrace
+            --parallel
             --build-cache

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ plugins {
 }
 
 group = "com.figure.gradle.semver"
-version = "2.0.1-SNAPSHOT"
+version = "2.0.1-rc.1"
 
 val testImplementation: Configuration by configurations.getting
 
@@ -210,23 +210,22 @@ gradlePlugin {
     }
 }
 
-val isStable = version.toString().matches("^\\d.\\d.\\d\$".toRegex())
+val isStable = providers.provider { version.toString().matches("^\\d.\\d.\\d\$".toRegex()) }
 
 afterEvaluate {
     publishing {
-        publications.filterIsInstance<MavenPublication>().forEach {
-            if (!isStable) {
-                repositories {
-                    maven {
-                        url = uri("https://nexus.figure.com/repository/figure")
-                        credentials {
-                            username = System.getenv("NEXUS_USER")
-                            password = System.getenv("NEXUS_PASS")
-                        }
+        if (!isStable.get()) {
+            repositories {
+                maven {
+                    url = uri("https://nexus.figure.com/repository/figure")
+                    credentials {
+                        username = System.getenv("NEXUS_USER")
+                        password = System.getenv("NEXUS_PASS")
                     }
                 }
             }
-
+        }
+        publications.filterIsInstance<MavenPublication>().forEach {
             it.pom {
                 name = info.name
                 description = info.description

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -210,9 +210,23 @@ gradlePlugin {
     }
 }
 
+val isStable = version.toString().matches("^\\d.\\d.\\d\$".toRegex())
+
 afterEvaluate {
     publishing {
         publications.filterIsInstance<MavenPublication>().forEach {
+            if (!isStable) {
+                repositories {
+                    maven {
+                        url = uri("https://nexus.figure.com/repository/figure")
+                        credentials {
+                            username = System.getenv("NEXUS_USER")
+                            password = System.getenv("NEXUS_PASS")
+                        }
+                    }
+                }
+            }
+
             it.pom {
                 name = info.name
                 description = info.description

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,7 +40,7 @@ plugins {
 }
 
 group = "com.figure.gradle.semver"
-version = "2.0.0"
+version = "2.0.1-SNAPSHOT"
 
 val testImplementation: Configuration by configurations.getting
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -13,6 +13,7 @@ detekt = "1.23.7"
 github-release = "2.5.2"
 gradle-testkit = "0.10"
 publish-plugin = "1.3.0"
+publish-base = "0.29.0"
 spotless = "6.25.0"
 test-logger = "4.0.0"
 testkit-support = "0.16"
@@ -36,5 +37,6 @@ github-release = { id = "com.github.breadmoirai.github-release", version.ref = "
 gradle-testkit = { id = "com.autonomousapps.testkit", version.ref = "gradle-testkit" }
 kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 publish-plugin = { id = "com.gradle.plugin-publish", version.ref = "publish-plugin" }
+publish-base = { id = "com.vanniktech.maven.publish.base", version.ref = "publish-base" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 test-logger = { id = "com.adarshr.test-logger", version.ref = "test-logger" }

--- a/src/functionalTest/kotlin/com/figure/gradle/semver/git/GitActions.kt
+++ b/src/functionalTest/kotlin/com/figure/gradle/semver/git/GitActions.kt
@@ -36,7 +36,7 @@ data class CheckoutAction(
     val branch: String,
 ) : Action {
     override fun execute(git: KGit) {
-        if (git.branch.headRef?.objectId?.name == null) {
+        if (git.branch.headRef.objectId?.name == null) {
             git.commit("Initial commit", allowEmptyCommit = true)
         }
 

--- a/src/main/kotlin/com/figure/gradle/semver/internal/command/Branch.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/command/Branch.kt
@@ -15,39 +15,25 @@
  */
 package com.figure.gradle.semver.internal.command
 
-import com.figure.gradle.semver.internal.command.extension.revWalk
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.Ref
-import org.eclipse.jgit.revwalk.RevCommit
 
 class Branch(
     private val git: Git,
     private val branchList: BranchList,
 ) {
-    private val githubHeadRef: String = "GITHUB_HEAD_REF"
-
     private val shortName: String
         get() = git.repository.branch
-
-    val fullName: String
-        get() = git.repository.fullBranch
 
     private val branchRef: Ref
         get() = git.repository.findRef(shortName)
 
-    val headRef: Ref?
+    val headRef: Ref
         get() = git.repository.exactRef(Constants.HEAD)
 
-    val headCommit: RevCommit
-        get() = git.revWalk { it.parseCommit(branchRef.objectId) }
-
     fun currentRef(forTesting: Boolean = false): Ref =
-        if (forTesting) {
-            branchRef
-        } else {
-            git.repository.findRef(System.getenv(githubHeadRef) ?: shortName)
-        }
+        if (forTesting) branchRef else headRef
 
     fun isOnMainBranch(providedMainBranch: String? = null, forTesting: Boolean = false): Boolean =
         currentRef(forTesting).name == branchList.findMainBranch(providedMainBranch).name


### PR DESCRIPTION
We should publish pre-releases to our internal repository instead of the public gradle plugin portal