### PR TITLE
fix: use strict equality for filtering branch names

### DIFF
--- a/src/functionalTest/kotlin/com/figure/gradle/semver/specs/CalculateNextVersionWithoutInputsSpec.kt
+++ b/src/functionalTest/kotlin/com/figure/gradle/semver/specs/CalculateNextVersionWithoutInputsSpec.kt
@@ -34,11 +34,12 @@ class CalculateNextVersionWithoutInputsSpec : FunSpec({
     )
 
     val mainBranch = "main"
+    val masterBranch = "master"
     val developmentBranch = "develop"
     val featureBranch = "myname/sc-123456/my-awesome-feature"
 
     context("should calculate next version without inputs") {
-        test("on main branch") {
+        test("on $mainBranch branch") {
             // Given
             projects.git {
                 initialBranch = mainBranch
@@ -57,7 +58,66 @@ class CalculateNextVersionWithoutInputsSpec : FunSpec({
             projects.versions shouldOnlyHave "1.0.1"
         }
 
-        test("on development branch") {
+        test("on $masterBranch branch") {
+            // Given
+            projects.git {
+                initialBranch = masterBranch
+                actions = actions {
+                    commit(message = "1 commit on $masterBranch", tag = "1.0.0")
+                    checkout(developmentBranch)
+                    commit(message = "1 commit on $developmentBranch")
+                    checkout(masterBranch)
+                }
+            }
+
+            // When
+            projects.build(GradleVersion.current())
+
+            // Then
+            projects.versions shouldOnlyHave "1.0.1"
+        }
+
+        test("on $masterBranch branch without tags") {
+            // Given
+            projects.git {
+                initialBranch = masterBranch
+                actions = actions {
+                    commit(message = "1 commit on $masterBranch")
+                    checkout(developmentBranch)
+                    commit(message = "1 commit on $developmentBranch")
+                    checkout(masterBranch)
+                }
+            }
+
+            // When
+            projects.build(GradleVersion.current())
+
+            // Then
+            projects.versions shouldOnlyHave "0.0.1"
+        }
+
+        test("on $masterBranch branch without tags where feature branch contains $masterBranch name") {
+            // Given
+            val masterFeatureBranch = "master-feature"
+
+            projects.git {
+                initialBranch = masterBranch
+                actions = actions {
+                    commit(message = "1 commit on $masterBranch")
+                    checkout(masterFeatureBranch)
+                    commit(message = "1 commit on $masterFeatureBranch")
+                    checkout(masterBranch)
+                }
+            }
+
+            // When
+            projects.build(GradleVersion.current())
+
+            // Then
+            projects.versions shouldOnlyHave "0.0.1"
+        }
+
+        test("on $developmentBranch branch") {
             // Given
             projects.git {
                 initialBranch = mainBranch
@@ -75,7 +135,7 @@ class CalculateNextVersionWithoutInputsSpec : FunSpec({
             projects.versions shouldOnlyHave "1.0.1-develop.1"
         }
 
-        test("on development branch with latest development tag") {
+        test("on $developmentBranch branch with latest development tag") {
             // Given
             projects.git {
                 initialBranch = mainBranch
@@ -95,7 +155,7 @@ class CalculateNextVersionWithoutInputsSpec : FunSpec({
             projects.versions shouldOnlyHave "1.0.1-develop.3"
         }
 
-        test("on feature branch off development branch") {
+        test("on $featureBranch branch off $developmentBranch branch") {
             // Given
             projects.git {
                 initialBranch = mainBranch
@@ -118,7 +178,7 @@ class CalculateNextVersionWithoutInputsSpec : FunSpec({
             projects.versions shouldOnlyHave "1.0.1-myname-sc-123456-my-awesome-feature.2"
         }
 
-        test("on feature branch off main branch") {
+        test("on $featureBranch branch off $mainBranch branch") {
             // Given
             projects.git {
                 initialBranch = mainBranch
@@ -138,7 +198,7 @@ class CalculateNextVersionWithoutInputsSpec : FunSpec({
             projects.versions shouldOnlyHave "1.0.1-myname-sc-123456-my-awesome-feature.2"
         }
 
-        test("for develop branch after committing to feature branch and switching back to develop") {
+        test("for $developmentBranch branch after committing to $featureBranch branch and switching back to $developmentBranch") {
             // Given
             projects.git {
                 initialBranch = mainBranch

--- a/src/main/kotlin/com/figure/gradle/semver/internal/calculator/BranchVersionCalculator.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/calculator/BranchVersionCalculator.kt
@@ -17,7 +17,7 @@ package com.figure.gradle.semver.internal.calculator
 
 import com.figure.gradle.semver.internal.command.KGit
 import com.figure.gradle.semver.internal.extensions.appendBuildMetadata
-import com.figure.gradle.semver.internal.extensions.sanitizedWithoutPrefix
+import com.figure.gradle.semver.internal.extensions.prereleaseLabel
 import io.github.z4kn4fein.semver.Version
 import io.github.z4kn4fein.semver.inc
 
@@ -38,7 +38,7 @@ class BranchVersionCalculator(
             kGit.branches.commitCountBetween(mainBranch.name, currentBranch.name)
         }
 
-        val prereleaseLabel = currentBranch.sanitizedWithoutPrefix()
+        val prereleaseLabel = currentBranch.prereleaseLabel()
         val prereleaseLabelWithCommitCount = "$prereleaseLabel.$commitCount"
 
         return latestVersion

--- a/src/main/kotlin/com/figure/gradle/semver/internal/command/Branch.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/command/Branch.kt
@@ -17,9 +17,14 @@ package com.figure.gradle.semver.internal.command
 
 import com.figure.gradle.semver.internal.command.extension.shortName
 import com.figure.gradle.semver.internal.environment.Env
+import com.figure.gradle.semver.internal.logging.info
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.Ref
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+
+private val log = Logging.getLogger(Logger.ROOT_LOGGER_NAME)
 
 class Branch(
     private val git: Git,
@@ -37,8 +42,13 @@ class Branch(
             return branchList.find(refName) ?: error("Could not find current branch: $refName")
         }
 
-    fun isOnMainBranch(providedMainBranch: String? = null): Boolean =
-        currentRef.shortName == branchList.findMainBranch(providedMainBranch).shortName
+    fun isOnMainBranch(providedMainBranch: String? = null): Boolean {
+        log.info { "Current ref: ${currentRef.shortName}" }
+        val mainBranchShortName = branchList.findMainBranch(providedMainBranch).shortName
+        log.info { "Main branch: $mainBranchShortName" }
+
+        return currentRef.shortName == branchList.findMainBranch(providedMainBranch).shortName
+    }
 
     fun create(branchName: String): Ref =
         git.branchCreate()

--- a/src/main/kotlin/com/figure/gradle/semver/internal/command/BranchList.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/command/BranchList.kt
@@ -16,12 +16,19 @@
 package com.figure.gradle.semver.internal.command
 
 import com.figure.gradle.semver.internal.command.extension.revWalk
+import com.figure.gradle.semver.internal.command.extension.shortName
 import com.figure.gradle.semver.internal.extensions.R_REMOTES_ORIGIN
+import com.figure.gradle.semver.internal.extensions.shortName
+import com.figure.gradle.semver.internal.logging.info
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.ListBranchCommand
 import org.eclipse.jgit.lib.Constants
 import org.eclipse.jgit.lib.ObjectId
 import org.eclipse.jgit.lib.Ref
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+
+private val log = Logging.getLogger(Logger.ROOT_LOGGER_NAME)
 
 class BranchList(
     private val git: Git,
@@ -69,6 +76,7 @@ class BranchList(
             ?.takeIf { it.isNotBlank() }
             ?.let { nonBlankBranchName ->
                 findAll(nonBlankBranchName).let { matchingBranches ->
+                    log.info { "Found matching branches: ${matchingBranches.map { it.name }}" }
                     matchingBranches.find { Constants.R_HEADS in it.name }
                         ?: matchingBranches.find { Constants.R_REMOTES in it.name }
                 }
@@ -81,7 +89,7 @@ class BranchList(
         git.branchList()
             .setListMode(ListBranchCommand.ListMode.ALL)
             .call()
-            .filter { branchName.lowercase() in it.name.lowercase() }
+            .filter { branchName.shortName() in it.shortName }
 
     fun commitCountBetween(baseBranchName: String, targetBranchName: String): Int {
         // Try to resolve the remote branch first, then fall back to the local branch

--- a/src/main/kotlin/com/figure/gradle/semver/internal/command/BranchList.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/command/BranchList.kt
@@ -89,7 +89,7 @@ class BranchList(
         git.branchList()
             .setListMode(ListBranchCommand.ListMode.ALL)
             .call()
-            .filter { branchName.shortName() in it.shortName }
+            .filter { branchName.shortName() == it.shortName }
 
     fun commitCountBetween(baseBranchName: String, targetBranchName: String): Int {
         // Try to resolve the remote branch first, then fall back to the local branch

--- a/src/main/kotlin/com/figure/gradle/semver/internal/command/extension/RefExtensions.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/command/extension/RefExtensions.kt
@@ -15,9 +15,14 @@
  */
 package com.figure.gradle.semver.internal.command.extension
 
-import org.eclipse.jgit.lib.Constants
+import com.figure.gradle.semver.internal.extensions.R_REMOTES_ORIGIN
+import org.eclipse.jgit.lib.Constants.R_HEADS
 import org.eclipse.jgit.lib.Ref
 
 val Ref.shortName: String
-    get() = name.replace(Constants.R_HEADS, "")
-        .replace("${Constants.R_REMOTES}${Constants.DEFAULT_REMOTE_NAME}/", "")
+    get() = name
+        .trim()
+        .lowercase()
+        .replace(R_HEADS, "")
+        .replace("$R_REMOTES_ORIGIN/", "")
+        .removePrefix("/")

--- a/src/main/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensions.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensions.kt
@@ -24,10 +24,17 @@ const val R_REMOTES_ORIGIN = "$R_REMOTES$DEFAULT_REMOTE_NAME"
 
 private val validCharacters: Regex = """[^0-9A-Za-z\-_.]+""".toRegex()
 
-fun Ref.sanitizedWithoutPrefix(): String =
+fun Ref.prereleaseLabel(): String =
     name.trim()
         .lowercase()
         .replace(R_HEADS, "")
         .replace("$R_REMOTES_ORIGIN/", "")
         .removePrefix("/")
         .replace(validCharacters, "-")
+
+fun String.shortName(): String =
+    trim()
+        .lowercase()
+        .replace(R_HEADS, "")
+        .replace("$R_REMOTES_ORIGIN/", "")
+        .removePrefix("/")


### PR DESCRIPTION
This fixes an issue where if one branch contains verbiage of another branch, like `master-feature` and `master`, `master-feature` branch may end up getting used somehow in the version calculation. We should be doing an exact matching process instead of partial matching.