### PR TITLE
fix(extensions): underscores are invalid in prerelease

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Figure Technologies
+ * Copyright (C) 2024-2025 Figure Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Figure Technologies
+ * Copyright (C) 2024-2025 Figure Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/figure/gradle/semver/internal/command/Branch.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/command/Branch.kt
@@ -34,7 +34,9 @@ class Branch(
                 Env.isCI -> Env.githubHeadRef ?: Env.githubRefName
                 else -> git.repository.branch
             }
-            return branchList.find(refName) ?: error("Could not find current branch: $refName")
+            return branchList.find(refName) 
+                ?: headRef.takeIf { !it.target.name.startsWith("refs/heads/") }
+                ?: error("Could not find current branch: $refName")
         }
 
     fun isOnMainBranch(providedMainBranch: String? = null): Boolean =

--- a/src/main/kotlin/com/figure/gradle/semver/internal/command/Branch.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/command/Branch.kt
@@ -34,9 +34,7 @@ class Branch(
                 Env.isCI -> Env.githubHeadRef ?: Env.githubRefName
                 else -> git.repository.branch
             }
-            return branchList.find(refName) 
-                ?: headRef.takeIf { !it.target.name.startsWith("refs/heads/") }
-                ?: error("Could not find current branch: $refName")
+            return branchList.find(refName) ?: error("Could not find current branch: $refName")
         }
 
     fun isOnMainBranch(providedMainBranch: String? = null): Boolean =

--- a/src/main/kotlin/com/figure/gradle/semver/internal/command/extension/RefExtensions.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/command/extension/RefExtensions.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Figure Technologies
+ * Copyright (C) 2025 Figure Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensions.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensions.kt
@@ -22,7 +22,7 @@ import org.eclipse.jgit.lib.Ref
 
 const val R_REMOTES_ORIGIN = "$R_REMOTES$DEFAULT_REMOTE_NAME"
 
-private val invalidSemverCharacters: Regex = """[^0-9A-Za-z\-.]+""".toRegex()
+private val validCharacters: Regex = """[^0-9A-Za-z\-.]+""".toRegex()
 
 fun Ref.prereleaseLabel(): String =
     name.trim()

--- a/src/main/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensions.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensions.kt
@@ -22,7 +22,7 @@ import org.eclipse.jgit.lib.Ref
 
 const val R_REMOTES_ORIGIN = "$R_REMOTES$DEFAULT_REMOTE_NAME"
 
-private val validCharacters: Regex = """[^0-9A-Za-z\-_.]+""".toRegex()
+private val validCharacters: Regex = """[^0-9A-Za-z\-.]+""".toRegex()
 
 fun Ref.prereleaseLabel(): String =
     name.trim()

--- a/src/main/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensions.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensions.kt
@@ -22,7 +22,11 @@ import org.eclipse.jgit.lib.Ref
 
 const val R_REMOTES_ORIGIN = "$R_REMOTES$DEFAULT_REMOTE_NAME"
 
-private val validCharacters: Regex = """[^0-9A-Za-z\-.]+""".toRegex()
+/**
+ * Regex pattern matching any character not allowed in branch names:
+ * excludes all except digits, letters, hyphens, and periods.
+ */
+private val invalidCharacters: Regex = """[^0-9A-Za-z\-.]+""".toRegex()
 
 fun Ref.prereleaseLabel(): String =
     name.trim()
@@ -30,7 +34,7 @@ fun Ref.prereleaseLabel(): String =
         .replace(R_HEADS, "")
         .replace("$R_REMOTES_ORIGIN/", "")
         .removePrefix("/")
-        .replace(validCharacters, "-")
+        .replace(invalidCharacters, "-")
 
 fun String.shortName(): String =
     trim()

--- a/src/main/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensions.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensions.kt
@@ -22,7 +22,7 @@ import org.eclipse.jgit.lib.Ref
 
 const val R_REMOTES_ORIGIN = "$R_REMOTES$DEFAULT_REMOTE_NAME"
 
-private val validCharacters: Regex = """[^0-9A-Za-z\-.]+""".toRegex()
+private val invalidSemverCharacters: Regex = """[^0-9A-Za-z\-.]+""".toRegex()
 
 fun Ref.prereleaseLabel(): String =
     name.trim()

--- a/src/test/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensionsKtSpec.kt
+++ b/src/test/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensionsKtSpec.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2024 Figure Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.figure.gradle.semver.internal.extensions
+
+import io.github.z4kn4fein.semver.nextPreRelease
+import io.github.z4kn4fein.semver.toVersion
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import org.eclipse.jgit.lib.Constants
+import org.eclipse.jgit.lib.ObjectId
+import org.eclipse.jgit.lib.Ref
+import org.eclipse.jgit.lib.Ref.Storage
+
+class RefExtensionsKtSpec : FunSpec({
+    test("prereleaseLabel for dependabot branch") {
+        // Create a test implementation of Ref
+        val branchName = "dependabot-github_actions-softprops-action-gh-release-2"
+        val fullRefName = Constants.R_HEADS + branchName
+
+        // Create a mock Ref with the specified branch name
+        val ref = object : Ref {
+            override fun getName(): String = fullRefName
+
+            override fun getObjectId(): ObjectId? = null
+
+            override fun getPeeledObjectId(): ObjectId? = null
+
+            override fun isPeeled(): Boolean = false
+
+            override fun getStorage(): Storage = Storage.LOOSE
+
+            override fun isSymbolic(): Boolean = false
+
+            override fun getTarget(): Ref? = null
+
+            override fun getLeaf(): Ref = this
+        }
+
+        // Test the prereleaseLabel extension function
+        val expectedLabel = "dependabot-github-actions-softprops-action-gh-release-2"
+        ref.prereleaseLabel() shouldBe expectedLabel
+
+        // Test the prereleaseLabel extension function produces valid preRelease values
+        val expectedVersion = "1.0.1-$expectedLabel".toVersion(true)
+        "1.0.0".toVersion(true).nextPreRelease(expectedLabel) shouldBe expectedVersion
+    }
+})

--- a/src/test/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensionsKtSpec.kt
+++ b/src/test/kotlin/com/figure/gradle/semver/internal/extensions/RefExtensionsKtSpec.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024 Figure Technologies
+ * Copyright (C) 2025 Figure Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
When using GitHub Actions & Dependabot I've been hitting the following:

```
1: Task failed with an exception.
-----------
* What went wrong:
A problem occurred configuring root project 'root-project'.
> io.github.z4kn4fein.semver.VersionFormatException: Pre-release part 'dependabot-github_actions-softprops-action-gh-release-2' contains an invalid character. (dependabot-github_actions-softprops-action-gh-release-2.1)
gradle/actions: Writing build results to /home/runner/work/_temp/.gradle-actions/build-results/__run-1758664924990.json
```

IIUC this boils down to an `_` being contributed to the prerelease label which clearly is not a valid character.

This PR includes a test demonstrating the problem, a fix, and a required commit to update the copyright headers 🤷 