### PR TITLE
fix(branching): cross-repo PR builds fail

### DIFF
--- a/.github/workflows/gradle-build.yaml
+++ b/.github/workflows/gradle-build.yaml
@@ -28,6 +28,12 @@ jobs:
         with:
           fetch-depth: 0
 
+      # Published plugin resolves GITHUB_HEAD_REF as a real branch. Forked PRs only have the
+      # merge/checkout commit, so materialize a local branch with that name before Gradle runs.
+      - name: Materialize PR head branch for semver
+        if: github.head_ref != ''
+        run: git branch -f "$GITHUB_HEAD_REF" HEAD
+
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Figure Technologies
+ * Copyright (C) 2024-2026 Figure Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2024-2025 Figure Technologies
+ * Copyright (C) 2024-2026 Figure Technologies
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/functionalTest/kotlin/com/figure/gradle/semver/specs/CrossRepositoryPullRequestSpec.kt
+++ b/src/functionalTest/kotlin/com/figure/gradle/semver/specs/CrossRepositoryPullRequestSpec.kt
@@ -1,0 +1,126 @@
+/*
+ * Copyright (C) 2024-2026 Figure Technologies
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.figure.gradle.semver.specs
+
+import com.figure.gradle.semver.internal.environment.Env
+import com.figure.gradle.semver.kotest.GradleProjectsExtension
+import com.figure.gradle.semver.kotest.shouldOnlyHave
+import com.figure.gradle.semver.projects.RegularProject
+import com.figure.gradle.semver.projects.SettingsProject
+import com.figure.gradle.semver.projects.SubprojectProject
+import io.kotest.core.extensions.install
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.extensions.system.OverrideMode
+import io.kotest.extensions.system.withEnvironment
+import org.gradle.util.GradleVersion
+
+class CrossRepositoryPullRequestSpec :
+    FunSpec({
+        val projects = install(
+            GradleProjectsExtension(
+                RegularProject(projectName = "regular-project"),
+                SettingsProject(projectName = "settings-project"),
+                SubprojectProject(projectName = "subproject-project"),
+            ),
+        )
+
+        val mainBranch = "main"
+        val developmentBranch = "develop"
+        val forkedFeatureBranch = "fix/builds-fail-cross-repo"
+
+        test("should calculate next version when cross-repo pull request has no local head branch") {
+            withEnvironment(
+                environment = mapOf(
+                    Env.CI to "true",
+                    Env.GITHUB_HEAD_REF to forkedFeatureBranch,
+                ),
+                mode = OverrideMode.SetOrOverride,
+            ) {
+                // Given
+                projects.git {
+                    initialBranch = mainBranch
+                    actions = actions {
+                        commit(message = "1 commit on $mainBranch", tag = "1.0.0")
+
+                        checkout(developmentBranch)
+                        commit(message = "1 commit on $developmentBranch")
+
+                        // Stay on main: fork branch name exists only in GITHUB_HEAD_REF
+                        checkout(mainBranch)
+                    }
+                }
+
+                // When
+                projects.build(GradleVersion.current())
+
+                // Then
+                projects.versions shouldOnlyHave "1.0.1-fix-builds-fail-cross-repo.0"
+            }
+        }
+
+        test("should prefer GITHUB_HEAD_REF when GITHUB_REF_NAME is merge ref") {
+            withEnvironment(
+                environment = mapOf(
+                    Env.CI to "true",
+                    Env.GITHUB_HEAD_REF to forkedFeatureBranch,
+                    Env.GITHUB_REF_NAME to "123/merge",
+                ),
+                mode = OverrideMode.SetOrOverride,
+            ) {
+                // Given
+                projects.git {
+                    initialBranch = mainBranch
+                    actions = actions {
+                        commit(message = "1 commit on $mainBranch", tag = "1.0.0")
+                        checkout(mainBranch)
+                    }
+                }
+
+                // When
+                projects.build(GradleVersion.current())
+
+                // Then
+                projects.versions shouldOnlyHave "1.0.1-fix-builds-fail-cross-repo.0"
+            }
+        }
+
+        test("should fall back to GITHUB_REF_NAME when GITHUB_HEAD_REF is empty") {
+            withEnvironment(
+                environment = mapOf(
+                    Env.CI to "true",
+                    Env.GITHUB_HEAD_REF to "",
+                    Env.GITHUB_REF_NAME to "feature-branch-fallback",
+                ),
+                mode = OverrideMode.SetOrOverride,
+            ) {
+                // Given
+                projects.git {
+                    initialBranch = mainBranch
+                    actions = actions {
+                        commit(message = "1 commit on $mainBranch", tag = "1.0.0")
+                        checkout("feature-branch-fallback")
+                        commit(message = "1 commit on feature branch")
+                    }
+                }
+
+                // When
+                projects.build(GradleVersion.current())
+
+                // Then
+                projects.versions shouldOnlyHave "1.0.1-feature-branch-fallback.1"
+            }
+        }
+    })

--- a/src/main/kotlin/com/figure/gradle/semver/internal/command/Branch.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/command/Branch.kt
@@ -19,6 +19,7 @@ import com.figure.gradle.semver.internal.command.extension.shortName
 import com.figure.gradle.semver.internal.environment.Env
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.lib.Constants
+import org.eclipse.jgit.lib.ObjectIdRef
 import org.eclipse.jgit.lib.Ref
 
 class Branch(
@@ -34,7 +35,21 @@ class Branch(
                 Env.isCI -> Env.githubHeadRef ?: Env.githubRefName
                 else -> git.repository.branch
             }
-            return branchList.find(refName) ?: error("Could not find current branch: $refName")
+            branchList.find(refName)?.let { return it }
+
+            // Cross-repo PRs: GITHUB_HEAD_REF names a fork branch that does not exist locally
+            // after actions/checkout of the merge commit. Keep the PR branch name for versioning.
+            if (Env.isCI && Env.githubHeadRef != null) {
+                val headObjectId = git.repository.resolve(Constants.HEAD)
+                    ?: error("Could not resolve HEAD for synthetic branch ref: ${Env.githubHeadRef}")
+                return ObjectIdRef.PeeledNonTag(
+                    Ref.Storage.LOOSE,
+                    "${Constants.R_HEADS}${Env.githubHeadRef}",
+                    headObjectId,
+                )
+            }
+
+            return headRef
         }
 
     fun isOnMainBranch(providedMainBranch: String? = null): Boolean =

--- a/src/main/kotlin/com/figure/gradle/semver/internal/command/BranchList.kt
+++ b/src/main/kotlin/com/figure/gradle/semver/internal/command/BranchList.kt
@@ -93,6 +93,9 @@ class BranchList(
             ?: git.repository.resolve(baseBranchName)
 
         val targetBranch: ObjectId = git.repository.resolve(targetBranchName)
+            // Synthetic refs (cross-repo PRs) are not in the ref database; HEAD is the checked-out tip
+            ?: git.repository.resolve(Constants.HEAD)
+            ?: error("Could not resolve target branch: $targetBranchName")
 
         return git.revWalk { revWalk ->
             revWalk.apply {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how the current git ref is determined in CI and alters commit-count resolution fallback behavior, which can affect version strings produced on build pipelines.
> 
> **Overview**
> Fixes version calculation in CI for **forked/cross-repository GitHub pull requests** where `GITHUB_HEAD_REF` points to a branch that doesn’t exist in the checked-out repo. `Branch.currentRef` now falls back to a synthetic `Ref` named from `GITHUB_HEAD_REF` (otherwise `HEAD`) instead of failing, and `BranchList.commitCountBetween` falls back to resolving `HEAD` when the target ref can’t be resolved.
> 
> Adds a new functional test suite (`CrossRepositoryPullRequestSpec`) covering: missing local branch with `GITHUB_HEAD_REF`, preferring `GITHUB_HEAD_REF` over `GITHUB_REF_NAME`, and falling back to `GITHUB_REF_NAME` when `GITHUB_HEAD_REF` is empty.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92867b541e9538f0db9e1fd07ed04a9e85d16d68. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->